### PR TITLE
Fix issues with GCC + Clang on Linux/OSX

### DIFF
--- a/include/bounce/common/math/math.h
+++ b/include/bounce/common/math/math.h
@@ -20,6 +20,7 @@
 #define B3_MATH_H
 
 #include <cmath>
+#include <cstdlib> // For abs() with integral types
 #include <bounce/common/settings.h>
 
 inline bool b3IsValid(float32 fx)

--- a/include/bounce/common/settings.h
+++ b/include/bounce/common/settings.h
@@ -116,7 +116,13 @@ typedef float float32;
 #define B3_MiB(n) (1024 * B3_KiB(n))
 #define B3_GiB(n) (1024 * B3_MiB(n))
 
-#define B3_FORCE_INLINE __forceinline
+#ifndef _MSC_VER
+  #ifdef __cplusplus
+  #define B3_FORCE_INLINE inline
+  #else
+  #define B3_FORCE_INLINE
+  #endif
+#endif
 
 #define B3_PROFILE(name) b3ProfileScope scope(name)
 


### PR DESCRIPTION
This PR makes the following changes:

 - Includes `<cstdlib>` in math.h so that the integral version of `std::abs` is available, on OSX + Clang the integral version can't be found (integral abs is in cstdlib, floating point in cmath>
 - Makes `B3_FORCE_INLINE` compatible with compilers which don't support `__forceinline`