### PR TITLE
Clean up MSVC /W4 warnings

### DIFF
--- a/include/bounce/collision/shapes/sphere.h
+++ b/include/bounce/collision/shapes/sphere.h
@@ -32,11 +32,13 @@ struct b3Sphere
 
 inline const b3Vec3& b3Sphere::GetVertex(u32 index) const
 {
+    B3_NOT_USED(index);
 	return vertex;
 }
 
 inline u32 b3Sphere::GetSupportVertex(const b3Vec3& direction) const
 {
+    B3_NOT_USED(direction);
 	return 0;
 }
 

--- a/include/bounce/common/settings.h
+++ b/include/bounce/common/settings.h
@@ -124,7 +124,11 @@ typedef float float32;
 # endif
 #endif
 
-#define B3_PROFILE(name) b3ProfileScope scope(name)
+#define B3_JOIN(a, b) a##b
+#define B3_CONCATENATE(a, b) B3_JOIN(a, b)
+#define B3_UNIQUE_NAME(name) B3_CONCATENATE(name, __LINE__)
+
+#define B3_PROFILE(name) b3ProfileScope B3_UNIQUE_NAME(scope)(name)
 
 // You should implement this function to use your own memory allocator.
 void* b3Alloc(u32 size);

--- a/include/bounce/dynamics/contacts/contact_cluster.h
+++ b/include/bounce/dynamics/contacts/contact_cluster.h
@@ -23,7 +23,7 @@
 #include <bounce/common/template/array.h>
 #include <bounce/dynamics/contacts/manifold.h>
 
-#define B3_NULL_CLUSTER (-1)
+#define B3_NULL_CLUSTER (0u - 1u)
 
 // Used for contact cluster reduction.
 struct b3ClusterVertex
@@ -41,7 +41,7 @@ struct b3Observation
 	u32 manifold;
 	u32 manifoldPoint;
 	b3Vec3 point; // normal
-	i32 cluster; // normal
+	u32 cluster; // normal
 };
 
 // A group of contact points with a similar contact normal.

--- a/src/bounce/collision/shapes/hull.cpp
+++ b/src/bounce/collision/shapes/hull.cpp
@@ -73,8 +73,7 @@ void b3Hull::Validate(const b3HalfEdge* e) const
 	do 
 	{
 		const b3HalfEdge* next = edges + e->next;
-		const b3HalfEdge* twin = edges + next->twin;
-		e = twin;
+		e = edges + next->twin;
 		B3_ASSERT(count < edgeCount);
 		++count;
 	} while (e != begin);

--- a/src/bounce/dynamics/contacts/collide/collide.cpp
+++ b/src/bounce/dynamics/contacts/collide/collide.cpp
@@ -143,6 +143,7 @@ void b3CollideCapsuleAndHullShapes(b3Manifold& manifold,
 	const b3Transform& xfB, const b3Shape* shapeB,
 	b3ConvexCache* cache)
 {
+    B3_NOT_USED(cache);
 	b3CapsuleShape* hullA = (b3CapsuleShape*)shapeA;
 	b3HullShape* hullB = (b3HullShape*)shapeB;
 	b3CollideCapsuleAndHull(manifold, xfA, hullA, xfB, hullB);

--- a/src/bounce/dynamics/contacts/collide/collide_hulls_cache.cpp
+++ b/src/bounce/dynamics/contacts/collide/collide_hulls_cache.cpp
@@ -115,12 +115,7 @@ static void b3RebuildFaceContact(b3Manifold& manifold,
 	const b3Transform& xf1, u32 index1, const b3HullShape* s1,
 	const b3Transform& xf2, const b3HullShape* s2, bool flipNormal)
 {
-	const b3Hull* hull1 = s1->m_hull;
-	float32 r1 = s1->m_radius;
 	const b3Body* body1 = s1->GetBody();
-
-	const b3Hull* hull2 = s2->m_hull;
-	float32 r2 = s2->m_radius;
 	const b3Body* body2 = s2->GetBody();
 
 	const b3Sweep& sweep1 = body1->GetSweep();

--- a/src/bounce/dynamics/contacts/contact.cpp
+++ b/src/bounce/dynamics/contacts/contact.cpp
@@ -42,12 +42,10 @@ void b3Contact::Update(b3ContactListener* listener)
 {
 	b3Shape* shapeA = GetShapeA();
 	b3Body* bodyA = shapeA->GetBody();
-	i32 proxyA = shapeA->m_broadPhaseID;
 	b3Transform xfA = bodyA->GetTransform();
 
 	b3Shape* shapeB = GetShapeB();
 	b3Body* bodyB = shapeB->GetBody();
-	i32 proxyB = shapeB->m_broadPhaseID;
 	b3Transform xfB = bodyB->GetTransform();
 
 	b3World* world = bodyA->GetWorld();

--- a/src/bounce/dynamics/contacts/contact_solver.cpp
+++ b/src/bounce/dynamics/contacts/contact_solver.cpp
@@ -186,7 +186,6 @@ void b3ContactSolver::InitializeConstraints()
 		for (u32 j = 0; j < manifoldCount; ++j)
 		{
 			b3Manifold* m = c->m_manifolds + j;
-			b3PositionConstraintManifold* pcm = pc->manifolds + j;
 			b3VelocityConstraintManifold* vcm = vc->manifolds + j;
 
 			b3WorldManifold wm;
@@ -201,8 +200,7 @@ void b3ContactSolver::InitializeConstraints()
 			for (u32 k = 0; k < pointCount; ++k)
 			{
 				b3WorldManifoldPoint* mp = wm.points + k;
-				
-				b3PositionConstraintPoint* pcp = pcm->points + k;
+
 				b3VelocityConstraintPoint* vcp = vcm->points + k;
 
 				b3Vec3 normal = mp->normal;

--- a/src/bounce/dynamics/contacts/convex_contact.cpp
+++ b/src/bounce/dynamics/contacts/convex_contact.cpp
@@ -23,6 +23,9 @@
 
 b3ConvexContact::b3ConvexContact(b3Shape* shapeA, b3Shape* shapeB)
 {
+    B3_NOT_USED(shapeA);
+    B3_NOT_USED(shapeB);
+
 	m_type = e_convexContact;
 
 	m_manifoldCapacity = 1;

--- a/src/bounce/dynamics/contacts/mesh_contact.cpp
+++ b/src/bounce/dynamics/contacts/mesh_contact.cpp
@@ -199,10 +199,6 @@ bool b3MeshContact::TestOverlap()
 	b3Body* bodyB = shapeB->GetBody();
 	b3Transform xfB = bodyB->GetTransform();
 
-	b3MeshShape* meshShapeB = (b3MeshShape*)shapeB;
-	const b3Mesh* meshB = meshShapeB->m_mesh;
-	const b3StaticTree* treeB = &meshB->tree;
-
 	// Test if at least one triangle of the shape B overlaps the shape A.
 	for (u32 i = 0; i < m_triangleCount; ++i)
 	{
@@ -251,15 +247,15 @@ void b3MeshContact::Collide()
 
 		b3TriangleHull hullB(v1, v2, v3);
 
-		b3HullShape shapeB;
-		shapeB.m_body = bodyB;
-		shapeB.m_hull = &hullB;
-		shapeB.m_radius = B3_HULL_RADIUS;
+		b3HullShape hullShapeB;
+		hullShapeB.m_body = bodyB;
+		hullShapeB.m_hull = &hullB;
+		hullShapeB.m_radius = B3_HULL_RADIUS;
 				
 		b3Manifold* manifold = tempManifolds + tempCount;
 		manifold->Initialize();
 		
-		b3CollideShapeAndShape(*manifold, xfA, shapeA, xfB, &shapeB, &triangleCache->cache);
+		b3CollideShapeAndShape(*manifold, xfA, shapeA, xfB, &hullShapeB, &triangleCache->cache);
 		
 		for (u32 j = 0; j < manifold->pointCount; ++j)
 		{

--- a/src/bounce/dynamics/draw_world.cpp
+++ b/src/bounce/dynamics/draw_world.cpp
@@ -78,9 +78,6 @@ void b3World::DebugDraw() const
 
 	for (b3Contact* c = m_contactMan.m_contactList.m_head; c; c = c->m_next)
 	{
-		const b3Shape* shapeA = c->GetShapeA();
-		const b3Shape* shapeB = c->GetShapeB();
-		
 		u32 manifoldCount = c->m_manifoldCount;
 		const b3Manifold* manifolds = c->m_manifolds;
 		
@@ -119,8 +116,8 @@ void b3World::DebugDraw() const
 			{
 				b3Vec3 p = wm.center;
 				b3Vec3 n = wm.normal;
-				b3Vec3 t1 = wm.tangent1;
-				b3Vec3 t2 = wm.tangent2;
+				t1 = wm.tangent1;
+				t2 = wm.tangent2;
 				
 				if (flags & b3Draw::e_contactNormalsFlag)
 				{
@@ -255,5 +252,5 @@ void b3World::DrawJoint(const b3Joint* joint) const
 
 void b3World::DrawContact(const b3Contact* c) const
 {
-
+    B3_NOT_USED(c);
 }

--- a/src/bounce/dynamics/joints/mouse_joint.cpp
+++ b/src/bounce/dynamics/joints/mouse_joint.cpp
@@ -83,6 +83,7 @@ void b3MouseJoint::SolveVelocityConstraints(const b3SolverData* data)
 
 bool b3MouseJoint::SolvePositionConstraints(const b3SolverData* data) 
 {
+    B3_NOT_USED(data);
 	// There is no position correction for this constraint.
 	return true;
 }

--- a/src/bounce/dynamics/joints/revolute_joint.cpp
+++ b/src/bounce/dynamics/joints/revolute_joint.cpp
@@ -409,9 +409,7 @@ void b3RevoluteJoint::SolveVelocityConstraints(const b3SolverData* data)
 	b3Vec3 vB = data->velocities[m_indexB].v;
 	b3Vec3 wB = data->velocities[m_indexB].w;
 
-	float32 mA = m_mA;
 	b3Mat33 iA = m_iA;
-	float32 mB = m_mB;
 	b3Mat33 iB = m_iB;
 
 	// Solve motor constraint.
@@ -517,13 +515,13 @@ bool b3RevoluteJoint::SolvePositionConstraints(const b3SolverData* data)
 		b3Quat fB = qB * m_localRotationB;
 		b3Quat q = b3Conjugate(m_referenceRotation) * b3Conjugate(fA) * fB;
 
-		b3Vec4 P_hinge = P_hinge_limit_mat(q);
+		b3Vec4 P_hinge_limit = P_hinge_limit_mat(q);
 
 		b3Mat44 G1 = -0.5f * iQ_mat(b3Conjugate(fA)) * iP_mat(fB);
 		b3Mat44 G2 =  0.5f * iQ_mat(b3Conjugate(fA)) * iP_mat(fB);
 
-		b3Vec3 J1 = P_hinge * G1 * PT;
-		b3Vec3 J2 = P_hinge * G2 * PT;
+		b3Vec3 J1 = P_hinge_limit * G1 * PT;
+		b3Vec3 J2 = P_hinge_limit * G2 * PT;
 
 		b3Vec3 J1T = J1;
 		b3Vec3 J2T = J2;

--- a/src/bounce/dynamics/rope/rope.cpp
+++ b/src/bounce/dynamics/rope/rope.cpp
@@ -289,7 +289,6 @@ void b3Rope::Step(float32 h)
 		b3RopeBody* link = m_links + j;
 		b3RopeBody* parent = link - 1;
 		b3MotionVec* S = link->m_S;
-		b3MotionVec& c = link->m_sc;
 		
 		b3SpInertia& I_A = link->m_I_A;
 		b3ForceVec& F_A = link->m_F_A;

--- a/src/bounce/dynamics/shapes/mesh_shape.cpp
+++ b/src/bounce/dynamics/shapes/mesh_shape.cpp
@@ -132,7 +132,6 @@ bool b3MeshShape::RayCast(b3RayCastOutput* output, const b3RayCastInput& input, 
 	b3Vec3 QA_x_QB = b3Cross(QA, QB);
 
 	b3Vec3 AB_x_AC = b3Cross(AB, AC);
-	float32 den = b3Dot(AB_x_AC, AB_x_AC);
 
 	float32 u = b3Dot(QB_x_QC, AB_x_AC);
 	float32 v = b3Dot(QC_x_QA, AB_x_AC);


### PR DESCRIPTION
When compiling bounce using MSVC with warning level 4 there's a handful of warnings emitted. This PR makes the following minor changes to clean those up:

- Mark unused parameters with B3_NOT_USED
- Rename variables that shadow
previous declarations with the same name
- Remove unused variables
- Add B3_UNIQUE_NAME macro to generate semi-unique identifiers and use
that for the profile scope variable name in B3_PROFILE
- Change b3Observation::cluster type from i32 to u32 for consistency with its usage in the rest of the code base