### PR TITLE
Fix build on ubuntu GCC-7.5

### DIFF
--- a/include/bounce/common/settings.h
+++ b/include/bounce/common/settings.h
@@ -31,6 +31,11 @@
 #include <stdarg.h>
 #include <stdint.h>
 
+#ifdef __GNUC__
+// required for placement new operator (at least in GCC-7.5)
+#include <new>
+#endif
+
 // Default allocation functions.
 void* b3Alloc_Default(u32 size);
 void b3Free_Default(void* block);

--- a/include/bounce/common/time.h
+++ b/include/bounce/common/time.h
@@ -179,7 +179,7 @@ public:
     {
         struct timespec c;
         clock_gettime(CLOCK_MONOTONIC, &c);
-        double dt = 1000.0 * double(c.tv_sec - c0.tv_sec) + 1.0e-6 * double(c.tv_nsec - c0.tv_nsec);
+        double dt = 1000.0 * double(c.tv_sec - m_c0.tv_sec) + 1.0e-6 * double(c.tv_nsec - m_c0.tv_nsec);
         m_c0 = c;
         Add(dt);
     }


### PR DESCRIPTION
Fixes build on ubuntu 18 with gcc-7.5.
Fixes 2 types of  errors:
1# 
```
/home/dee/dev/test/bounce/include/bounce/common/time.h:182:48: error: ‘c0’ was not declared in this scope
         double dt = 1000.0 * double(c.tv_sec - c0.tv_sec) + 1.0e-6 * double(c.tv_nsec - c0.tv_nsec);
```
2#
```
bounce/dynamics/contacts/hull_sphere_contact.cpp:27:60: error: no matching function for call to ‘operator new(sizetype, void*&)’
  return new (mem) b3HullAndSphereContact(fixtureA, fixtureB);
  
/bounce/dynamics/contacts/triangle_capsule_contact.cpp:27:65: error: no matching function for call to ‘operator new(sizetype, void*&)’
  return new (mem) b3TriangleAndCapsuleContact(fixtureA, fixtureB);
etc.
```